### PR TITLE
Enhance parent post selection with autocomplete in editor

### DIFF
--- a/ABCD.Application.Tests/PostServiceTests.cs
+++ b/ABCD.Application.Tests/PostServiceTests.cs
@@ -41,6 +41,62 @@ namespace ABCD.Application.Tests {
             var service = new PostService(_context, _postRepoMock.Object);
             await Assert.ThrowsAsync<VersionConflictException>(() => service.UpdateFragmentAsync(command));
         }
+
+        [Fact]
+        public async Task UpdatePostAsync_SetsParent_WhenParentPostIdProvided()
+        {
+            var command = new UpdatePostCommand(999, "Updated Title", string.Empty, "updated-path", 77, "0x11");
+            var parent = new Post(new BlogId(1), new PostId(77), "Parent", PostStatus.Published, DateTime.UtcNow)
+            {
+                PathSegment = new PathSegment("parent-path")
+            };
+            var post = new Post(new BlogId(1), new PostId(999), "Title", PostStatus.Draft)
+            {
+                PathSegment = new PathSegment("old-path"),
+                Version = new VersionToken("11")
+            };
+
+            _postRepoMock.Setup(r => r.GetByPostIdAsync(1, 999)).ReturnsAsync(post);
+            _postRepoMock.Setup(r => r.GetByPostIdAsync(1, 77)).ReturnsAsync(parent);
+            _postRepoMock.Setup(r => r.GetByBlogIdAndPathSegmentAsync(1, "updated-path")).ReturnsAsync((Post)null);
+            _postRepoMock.Setup(r => r.UpdatePostFragmentsAsync(It.IsAny<Post>())).ReturnsAsync((Post updated) => updated);
+
+            var service = new PostService(_context, _postRepoMock.Object);
+            var result = await service.UpdatePostAsync(command);
+
+            Assert.Equal(parent, result.Parent);
+            _postRepoMock.Verify(r => r.UpdatePostFragmentsAsync(It.Is<Post>(p =>
+                p.Title == "Updated Title" &&
+                p.PathSegment != null &&
+                p.PathSegment.Value == "updated-path" &&
+                p.Parent == parent)), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdatePostAsync_ClearsParent_WhenParentPostIdIsNull()
+        {
+            var existingParent = new Post(new BlogId(1), new PostId(77), "Parent", PostStatus.Published, DateTime.UtcNow)
+            {
+                PathSegment = new PathSegment("parent-path")
+            };
+            var post = new Post(new BlogId(1), new PostId(999), "Title", PostStatus.Draft)
+            {
+                PathSegment = new PathSegment("old-path"),
+                Version = new VersionToken("11"),
+                Parent = existingParent
+            };
+            var command = new UpdatePostCommand(999, "Updated Title", string.Empty, "updated-path", null, "0x11");
+
+            _postRepoMock.Setup(r => r.GetByPostIdAsync(1, 999)).ReturnsAsync(post);
+            _postRepoMock.Setup(r => r.GetByBlogIdAndPathSegmentAsync(1, "updated-path")).ReturnsAsync((Post)null);
+            _postRepoMock.Setup(r => r.UpdatePostFragmentsAsync(It.IsAny<Post>())).ReturnsAsync((Post updated) => updated);
+
+            var service = new PostService(_context, _postRepoMock.Object);
+            var result = await service.UpdatePostAsync(command);
+
+            Assert.Null(result.Parent);
+            _postRepoMock.Verify(r => r.UpdatePostFragmentsAsync(It.Is<Post>(p => p.Parent == null)), Times.Once);
+        }
         
         private readonly Mock<IPostRepository> _postRepoMock = new();
         private readonly Blog _blog = new(new BlogId(1)) { Name = "Test Blog" };

--- a/ABCD.Application/Commands.cs
+++ b/ABCD.Application/Commands.cs
@@ -7,5 +7,5 @@
 
     public record UpdateFragmentCommand(int PostId, int FragmentId, string Content, string Version);
 
-    public record UpdatePostCommand(int PostId, string Title, string Synopsis, string PathSegment, string Version);
+    public record UpdatePostCommand(int PostId, string Title, string Synopsis, string PathSegment, int? ParentPostId, string Version);
 }

--- a/ABCD.Application/IPostService.cs
+++ b/ABCD.Application/IPostService.cs
@@ -13,5 +13,6 @@ namespace ABCD.Application {
         Task<Post> UpdateFragmentAsync(UpdateFragmentCommand command);
         Task<Post> DeleteFragmentAsync(DeleteFragmentCommand command);
         Task<Post> TogglePostStatusAsync(TogglePostStatusCommand command);
+        Task<IEnumerable<Post>> SearchAsync(string searchTerm, int? excludePostId = null);
     }
 }

--- a/ABCD.Application/PostService.cs
+++ b/ABCD.Application/PostService.cs
@@ -93,14 +93,23 @@ namespace ABCD.Application {
 
         public async Task<Post> UpdatePostAsync(UpdatePostCommand command) {
             var post = await TryGetPostByIdAndVersion(command.PostId, command.Version);
-            var postWithSamePathSegment = await _postRepository.GetByBlogIdAndPathSegmentAsync(_requestContext.Blog.BlogId.Value!, command.PathSegment?.Trim());
+            var trimmedPathSegment = command.PathSegment.Trim();
+            var postWithSamePathSegment = await _postRepository.GetByBlogIdAndPathSegmentAsync(_requestContext.Blog.BlogId.Value!, trimmedPathSegment);
 
             if(postWithSamePathSegment != null && postWithSamePathSegment.PostId != post.PostId)
                 throw new DuplicatePathSegmentException($"A post with the path segment '{command.PathSegment}' already exists in this blog.");
 
+            Post? parent = null;
+            if (command.ParentPostId.HasValue) {
+                parent = await _postRepository.GetByPostIdAsync(_requestContext.Blog.BlogId.Value!, command.ParentPostId.Value);
+                if (parent == null)
+                    throw new PostNotFoundException($"Parent post {command.ParentPostId.Value} does not exist.");
+            }
+
             post.Title = command.Title;
             //post.Synopsis = command.Synopsis;
-            post.PathSegment = new PathSegment(command.PathSegment);
+            post.PathSegment = new PathSegment(trimmedPathSegment);
+            post.Parent = parent;
             return await _postRepository.UpdatePostFragmentsAsync(post);
         }
 

--- a/ABCD.Application/PostService.cs
+++ b/ABCD.Application/PostService.cs
@@ -121,5 +121,9 @@ namespace ABCD.Application {
                 post.Publish();
             return await _postRepository.UpdatePostStatusAsync(post);
         }
+
+        public async Task<IEnumerable<Post>> SearchAsync(string searchTerm, int? excludePostId = null) {
+            return await _postRepository.SearchByTitleOrPathAsync(_requestContext.Blog.BlogId.Value!, searchTerm, excludePostId);
+        }
     }
 }

--- a/ABCD.Domain/IPostRepository.cs
+++ b/ABCD.Domain/IPostRepository.cs
@@ -10,5 +10,6 @@
         Task<Post> UpdatePostFragmentAsync(Post post, Fragment fragment);
         Task<Post> UpdatePostFragmentsAsync(Post post);
         Task<Post> UpdatePostStatusAsync(Post post);
+        Task<IEnumerable<Post>> SearchByTitleOrPathAsync(int blogId, string searchTerm, int? excludePostId = null, int maxResults = 10);
     }
 }

--- a/ABCD.Infra/Data/PostRepository.cs
+++ b/ABCD.Infra/Data/PostRepository.cs
@@ -63,11 +63,16 @@ namespace ABCD.Infra.Data {
 
         // Map EF record to domain model
         private Post MapToDomain(PostRecord record) {
-            // TODO: Map all required fields and relationships
+            return MapToDomain(record, new HashSet<int>());
+        }
+
+        private Post MapToDomain(PostRecord record, ISet<int> visitedPostIds) {
+            if (!visitedPostIds.Add(record.PostId))
+                throw new ArgumentException($"Circular parent relationship detected for post {record.PostId}.", nameof(record));
+
             var fragments = new List<Fragment>();
             if (record.Fragments != null) {
                 foreach (var fragmentRecord in record.Fragments) {
-                    // Assuming Fragment is a domain model and you have a method to map from record to domain
                     fragments.Add(MapToDomain(fragmentRecord));
                 }
             }
@@ -75,7 +80,21 @@ namespace ABCD.Infra.Data {
                                 record.Title, (PostStatus)record.Status, record.DateLastPublished, fragments) { 
                 PathSegment = record.PathSegment != null ? new PathSegment(record.PathSegment) : null,
                 Version = new VersionToken(record.Version)
-            };            
+            };
+
+            if (record.ParentPostId.HasValue) {
+                var parentRecord = record.ParentPost;
+                if (parentRecord == null) {
+                    parentRecord = _context.Posts
+                        .AsNoTracking()
+                        .FirstOrDefault(p => p.PostId == record.ParentPostId.Value);
+                }
+
+                if (parentRecord != null)
+                    post.Parent = MapToDomain(parentRecord, visitedPostIds);
+            }
+
+            visitedPostIds.Remove(record.PostId);
             return post;
         }
 
@@ -97,6 +116,7 @@ namespace ABCD.Infra.Data {
                 BlogId = post.BlogId.Value,
                 Title = post.Title,
                 Status = post.Status,
+                ParentPostId = post.Parent?.PostId?.Value,
                 PathSegment = post.PathSegment?.Value,
                 DateLastPublished = post.DateLastPublished,
                 Version = post.Version?.Value ?? Array.Empty<byte>(),
@@ -172,6 +192,7 @@ namespace ABCD.Infra.Data {
 
             trackedPost.Title = post.Title;
             trackedPost.PathSegment = post.PathSegment?.Value;
+            trackedPost.ParentPostId = post.Parent?.PostId?.Value;
             trackedPost.UpdatedDate = DateTime.UtcNow;
 
             _context.Entry(trackedPost).State = EntityState.Modified;

--- a/ABCD.Infra/Data/PostRepository.cs
+++ b/ABCD.Infra/Data/PostRepository.cs
@@ -61,6 +61,23 @@ namespace ABCD.Infra.Data {
             return MapToDomain(record);
         }
 
+        public async Task<IEnumerable<Post>> SearchByTitleOrPathAsync(int blogId, string searchTerm, int? excludePostId = null, int maxResults = 10) {
+            var pattern = $"%{searchTerm}%";
+            var query = _context.Posts
+                .Where(p => p.BlogId == blogId &&
+                    (EF.Functions.Like(p.Title, pattern) || EF.Functions.Like(p.PathSegment!, pattern)));
+
+            if (excludePostId.HasValue)
+                query = query.Where(p => p.PostId != excludePostId.Value);
+
+            var records = await query
+                .OrderBy(p => p.Title)
+                .Take(maxResults)
+                .ToListAsync();
+
+            return records.Select(MapToDomain);
+        }
+
         // Map EF record to domain model
         private Post MapToDomain(PostRecord record) {
             return MapToDomain(record, new HashSet<int>());

--- a/ABCD.Server/Controllers/PostsController.cs
+++ b/ABCD.Server/Controllers/PostsController.cs
@@ -58,7 +58,7 @@ namespace ABCD.Server.Controllers
             if (string.IsNullOrWhiteSpace(request?.Version))
                 return BadRequest("Invalid request or missing version.");
 
-            var command = new UpdatePostCommand(postId, request.Title, request.Synopsis, request.PathSegment, request.Version);
+            var command = new UpdatePostCommand(postId, request.Title, request.Synopsis, request.PathSegment, request.ParentPostId, request.Version);
             var result = await _postService.UpdatePostAsync(command);
             var response = _typeMapper.Map<Post, PostDetailResponse>(result);
             return Ok(response);

--- a/ABCD.Server/Controllers/PostsController.cs
+++ b/ABCD.Server/Controllers/PostsController.cs
@@ -41,6 +41,17 @@ namespace ABCD.Server.Controllers
             return Ok(response);
         }
 
+        [HttpGet("search")]
+        public async Task<IActionResult> Search([FromQuery] string term, [FromQuery] int? excludePostId)
+        {
+            if (string.IsNullOrWhiteSpace(term) || term.Trim().Length < 3)
+                return Ok(Array.Empty<PostSummaryResponse>());
+
+            var posts = await _postService.SearchAsync(term.Trim(), excludePostId);
+            var response = _typeMapper.Map<IEnumerable<Post>, IEnumerable<PostSummaryResponse>>(posts);
+            return Ok(response);
+        }
+
         [HttpGet("{postId:int}")]
         public async Task<IActionResult> GetPostById([FromRoute] int postId) {
             var post = await _postService.GetByIdAsync(postId);

--- a/ABCD.Server/Middlewares/ExceptionHandlingMiddleware.cs
+++ b/ABCD.Server/Middlewares/ExceptionHandlingMiddleware.cs
@@ -13,6 +13,8 @@ namespace ABCD.Server.Middlewares {
         {
             { typeof(ImageUploadException), StatusCodes.Status400BadRequest},
             { typeof(IllegalOperationException), StatusCodes.Status400BadRequest },
+            { typeof(ArgumentException), StatusCodes.Status400BadRequest },
+            { typeof(ArgumentNullException), StatusCodes.Status400BadRequest },
             { typeof(InvalidFragmentException), StatusCodes.Status400BadRequest },
             { typeof(DuplicatePathSegmentException), StatusCodes.Status400BadRequest },
             { typeof(DuplicatePostTitleException), StatusCodes.Status400BadRequest },

--- a/ABCD.Server/Models/PostModels.cs
+++ b/ABCD.Server/Models/PostModels.cs
@@ -31,6 +31,7 @@ namespace ABCD.Server.Models
         public int PostId { get; init; }
         public string Title { get; init; } = string.Empty;
         public string? PathSegment { get; init; }
+        public string Status { get; init; } = string.Empty;
     }
 
     public record PostDetailResponse {

--- a/ABCD.Server/Models/PostModels.cs
+++ b/ABCD.Server/Models/PostModels.cs
@@ -26,6 +26,13 @@ namespace ABCD.Server.Models
         public string Version { get; init; } = string.Empty;
     }
 
+    public record PostParentResponse
+    {
+        public int PostId { get; init; }
+        public string Title { get; init; } = string.Empty;
+        public string? PathSegment { get; init; }
+    }
+
     public record PostDetailResponse {
         public int PostId { get; init; }
         public int BlogId { get; init; }
@@ -33,6 +40,7 @@ namespace ABCD.Server.Models
         public string Content { get; init; } = string.Empty;
         public string Status { get; init; } = string.Empty;
         public string? PathSegment { get; init; }
+        public PostParentResponse? Parent { get; init; }
         public DateTime? DateLastPublished { get; init; }
         public DateTime DateCreated { get; init; }
         public DateTime DateModified { get; init; }

--- a/ABCD.Server/Models/PostUpdateRequest.cs
+++ b/ABCD.Server/Models/PostUpdateRequest.cs
@@ -4,6 +4,7 @@ namespace ABCD.Server.Models
         string Title,
         string? Synopsis,
         string PathSegment,
+        int? ParentPostId,
         string Version
     );
 }

--- a/ABCD.Server/Program.cs
+++ b/ABCD.Server/Program.cs
@@ -147,6 +147,12 @@ config.NewConfig<Fragment, FragmentResponse>()
     .Map(dest => dest.Content, src => src.Content != null ? src.Content : null)
     .Map(dest => dest.Position, src => src.Position);
 
+config.NewConfig<Post, PostParentResponse>()
+    .Map(dest => dest.PostId, src => src.PostId != null ? src.PostId.Value : 0)
+    .Map(dest => dest.Title, src => src.Title)
+    .Map(dest => dest.PathSegment, src => src.PathSegment != null ? src.PathSegment.Value : null)
+    .Map(dest => dest.Status, src => src.Status.ToString());
+
 config.NewConfig<Post, PostDetailResponse>()
 .Map(dest => dest.PostId, src => src.PostId != null ? src.PostId.Value : 0)
 .Map(dest => dest.BlogId, src => src.BlogId.Value)

--- a/abcd.client/src/app/editor/edit-post/edit-post.component.html
+++ b/abcd.client/src/app/editor/edit-post/edit-post.component.html
@@ -55,6 +55,22 @@
                     <label class="label is-floating-label" for="pathSegment">Path Segment</label>
                   </div>
                 </div>
+                <div class="field">
+                  <label class="label" for="parentPostId">Parent Post</label>
+                  <div class="control">
+                    <div class="select is-fullwidth">
+                      <select id="parentPostId" [(ngModel)]="selectedParentPostId" name="parentPostId" [disabled]="!isHeaderEditing">
+                        <option [ngValue]="null">No parent post</option>
+                        @for (option of parentOptions; track option.postId) {
+                          <option [ngValue]="option.postId">
+                            {{ option.title }}{{ option.pathSegment ? ' (' + option.pathSegment + ')' : '' }} - {{ option.status }}
+                          </option>
+                        }
+                      </select>
+                    </div>
+                  </div>
+                  <p class="help">Optional. Choose a parent to place this post in a series or trail.</p>
+                </div>
               </app-editable-generic>
               @if (post.fragments.length === 0) {
                 <div class="has-text-centered py-5">

--- a/abcd.client/src/app/editor/edit-post/edit-post.component.html
+++ b/abcd.client/src/app/editor/edit-post/edit-post.component.html
@@ -56,18 +56,22 @@
                   </div>
                 </div>
                 <div class="field">
-                  <label class="label" for="parentPostId">Parent Post</label>
-                  <div class="control">
-                    <div class="select is-fullwidth">
-                      <select id="parentPostId" [(ngModel)]="selectedParentPostId" name="parentPostId" [disabled]="!isHeaderEditing">
-                        <option [ngValue]="null">No parent post</option>
-                        @for (option of parentOptions; track option.postId) {
-                          <option [ngValue]="option.postId">
-                            {{ option.title }}{{ option.pathSegment ? ' (' + option.pathSegment + ')' : '' }} - {{ option.status }}
-                          </option>
-                        }
-                      </select>
-                    </div>
+                  <div class="control has-floating-label">
+                    <app-post-autocomplete
+                      [selectedPostId]="selectedParentPostId"
+                      [excludePostId]="post.postId"
+                      [initialDisplayText]="parentDisplayText"
+                      [disabled]="!isHeaderEditing"
+                      (selectedPostIdChange)="selectedParentPostId = $event.postId; parentDisplayText = $event.displayText">
+                    </app-post-autocomplete>
+                    <label class="label is-floating-label">
+                      Parent Post
+                      @if (selectedParentPostId != null) {
+                        <a [routerLink]="['/editor/edit', selectedParentPostId]" target="_blank" title="Open parent post in new tab" class="has-text-link">
+                          <i class="fas fa-external-link-alt" style="font-size: 0.7rem;"></i>
+                        </a>
+                      }
+                    </label>
                   </div>
                   <p class="help">Optional. Choose a parent to place this post in a series or trail.</p>
                 </div>

--- a/abcd.client/src/app/editor/edit-post/edit-post.component.ts
+++ b/abcd.client/src/app/editor/edit-post/edit-post.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Post } from '../models/post.model'; 
-import { EditorPostSummary, PostService } from '../../services/post.service';
+import { PostService } from '../../services/post.service';
 import { Fragment } from '../models/fragment.model';
 import { MoveFragmentRequest } from '../models/move-fragment-request.model';
 import { FragmentUpdateRequest } from '../models/fragment-update-request.model';
@@ -18,9 +18,9 @@ export class EditPostComponent implements OnInit {
   activeAddFragmentDropdownId: number | null = null;
   isHeaderEditing: boolean = false;
   isAddFirstFragmentOpen: boolean = false;
-  parentOptions: EditorPostSummary[] = [];
   selectedParentPostId: number | null = null;
-  originalHeader: { title: string; synopsis: string; pathSegment?: string; parentPostId: number | null } | null = null;
+  parentDisplayText: string = '';
+  originalHeader: { title: string; synopsis: string; pathSegment?: string; parentPostId: number | null; parentDisplayText: string } | null = null;
 
   constructor(
     private route: ActivatedRoute,
@@ -30,15 +30,17 @@ export class EditPostComponent implements OnInit {
   ngOnInit(): void {
     const postId = Number(this.route.snapshot.paramMap.get('postId'));
 
-    this.postService.getPosts().subscribe(posts => {
-      this.parentOptions = posts
-        .filter(post => post.postId !== postId)
-        .sort((left, right) => left.title.localeCompare(right.title));
-    });
-
     this.postService.getPost(postId).subscribe(post => {
       this.post = post;
       this.selectedParentPostId = post.parent?.postId ?? null;
+      if (post.parent) {
+        let text = post.parent.title;
+        if (post.parent.pathSegment) {
+          text += ` (${post.parent.pathSegment})`;
+        }
+        text += ` - ${post.parent.status}`;
+        this.parentDisplayText = text;
+      }
     });
   }
 
@@ -173,9 +175,16 @@ export class EditPostComponent implements OnInit {
         title: this.post.title,
         synopsis: this.post.synopsis ?? '',
         pathSegment: this.post.pathSegment,
-        parentPostId: this.selectedParentPostId
+        parentPostId: this.selectedParentPostId,
+        parentDisplayText: this.parentDisplayText
       };
     }
+  }
+
+  onParentPostChange(event: { postId: number | null, displayText: string }) {
+    console.log(event.postId + " - " + event.displayText);
+    this.selectedParentPostId = event.postId;
+    this.parentDisplayText = event.displayText;
   }
 
   onHeaderCancel() {
@@ -185,6 +194,7 @@ export class EditPostComponent implements OnInit {
       this.post.synopsis = this.originalHeader.synopsis;
       this.post.pathSegment = this.originalHeader.pathSegment;
       this.selectedParentPostId = this.originalHeader.parentPostId;
+      this.parentDisplayText = this.originalHeader.parentDisplayText;
     }
   }
 

--- a/abcd.client/src/app/editor/edit-post/edit-post.component.ts
+++ b/abcd.client/src/app/editor/edit-post/edit-post.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Post } from '../models/post.model'; 
-import { PostService } from '../../services/post.service';
+import { EditorPostSummary, PostService } from '../../services/post.service';
 import { Fragment } from '../models/fragment.model';
 import { MoveFragmentRequest } from '../models/move-fragment-request.model';
 import { FragmentUpdateRequest } from '../models/fragment-update-request.model';
@@ -18,7 +18,9 @@ export class EditPostComponent implements OnInit {
   activeAddFragmentDropdownId: number | null = null;
   isHeaderEditing: boolean = false;
   isAddFirstFragmentOpen: boolean = false;
-  originalHeader: { title: string; synopsis: string; pathSegment?: string } | null = null;
+  parentOptions: EditorPostSummary[] = [];
+  selectedParentPostId: number | null = null;
+  originalHeader: { title: string; synopsis: string; pathSegment?: string; parentPostId: number | null } | null = null;
 
   constructor(
     private route: ActivatedRoute,
@@ -27,8 +29,16 @@ export class EditPostComponent implements OnInit {
 
   ngOnInit(): void {
     const postId = Number(this.route.snapshot.paramMap.get('postId'));
+
+    this.postService.getPosts().subscribe(posts => {
+      this.parentOptions = posts
+        .filter(post => post.postId !== postId)
+        .sort((left, right) => left.title.localeCompare(right.title));
+    });
+
     this.postService.getPost(postId).subscribe(post => {
       this.post = post;
+      this.selectedParentPostId = post.parent?.postId ?? null;
     });
   }
 
@@ -162,7 +172,8 @@ export class EditPostComponent implements OnInit {
       this.originalHeader = {
         title: this.post.title,
         synopsis: this.post.synopsis ?? '',
-        pathSegment: this.post.pathSegment
+        pathSegment: this.post.pathSegment,
+        parentPostId: this.selectedParentPostId
       };
     }
   }
@@ -173,20 +184,28 @@ export class EditPostComponent implements OnInit {
       this.post.title = this.originalHeader.title;
       this.post.synopsis = this.originalHeader.synopsis;
       this.post.pathSegment = this.originalHeader.pathSegment;
+      this.selectedParentPostId = this.originalHeader.parentPostId;
     }
   }
 
   onHeaderSave() {
     if (!this.post) return;
-    this.postService.savePost(this.post)
+    this.postService.savePost(this.post, this.selectedParentPostId)
       .subscribe({
         next: (updatedPost: Post) => {
           this.post = updatedPost;
+          this.selectedParentPostId = updatedPost.parent?.postId ?? null;
           this.errorMessage = null;
           this.isHeaderEditing = false;
         },
         error: (err) => {
-          this.errorMessage = 'Failed to update post.';
+          if (err?.error && typeof err.error === 'string') {
+            this.errorMessage = err.error;
+          } else if (err?.error?.message) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Failed to update post.';
+          }
           this.isHeaderEditing = true;
         }
       });

--- a/abcd.client/src/app/editor/editor.module.ts
+++ b/abcd.client/src/app/editor/editor.module.ts
@@ -15,6 +15,7 @@ import { TableFragmentComponent } from './table-fragment/table-fragment.componen
 import { CodeFragmentComponent } from './code-fragment/code-fragment.component';
 import { AiChatComponent } from './ai-chat/ai-chat.component';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
+import { PostAutocompleteComponent } from './post-autocomplete/post-autocomplete.component';
 
 @NgModule({
   declarations: [
@@ -33,6 +34,7 @@ import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
     FormsModule,
     EditorRoutingModule,
     CreatePostComponent,
+    PostAutocompleteComponent,
     NgxEditorModule,
     MonacoEditorModule.forRoot()
   ]

--- a/abcd.client/src/app/editor/models/post.model.ts
+++ b/abcd.client/src/app/editor/models/post.model.ts
@@ -1,5 +1,11 @@
 import { Fragment } from './fragment.model';
 
+export interface ParentPost {
+  postId: number;
+  title: string;
+  pathSegment?: string;
+}
+
 export class Post {
   postId: number;
   title: string;
@@ -7,6 +13,7 @@ export class Post {
   dateLastPublished?: string;
   pathSegment?: string;
   synopsis?: string;
+  parent?: ParentPost | null;
   version: string = '';
   canPublish: boolean = false;
   publishReasons: string[] = [];

--- a/abcd.client/src/app/editor/models/post.model.ts
+++ b/abcd.client/src/app/editor/models/post.model.ts
@@ -4,6 +4,7 @@ export interface ParentPost {
   postId: number;
   title: string;
   pathSegment?: string;
+  status: string;
 }
 
 export class Post {

--- a/abcd.client/src/app/editor/post-autocomplete/post-autocomplete.component.css
+++ b/abcd.client/src/app/editor/post-autocomplete/post-autocomplete.component.css
@@ -1,0 +1,50 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+:host ::ng-deep a.dropdown-item.is-active {
+  background-color: #f5f5f5;
+  color: #363636;
+}
+
+:host ::ng-deep .dropdown {
+  display: block;
+  width: 100%;
+}
+
+:host ::ng-deep .dropdown-trigger,
+:host ::ng-deep .dropdown-menu {
+  width: 100%;
+}
+
+:host .input.is-medium.with-floating-label {
+  height: 3.75rem;
+  padding-top: 1.5rem;
+}
+
+:host .selected-post-tag {
+  margin-bottom: 0;
+}
+
+:host .selected-post-tag .message-header {
+  min-height: 3.75rem;
+  padding: 1.5rem 1rem 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 0;
+  border: none;
+  border-bottom: 2px solid #dbdbdb;
+  background-color: transparent;
+  color: #363636;
+}
+
+:host .selected-post-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #363636;
+}

--- a/abcd.client/src/app/editor/post-autocomplete/post-autocomplete.component.html
+++ b/abcd.client/src/app/editor/post-autocomplete/post-autocomplete.component.html
@@ -1,0 +1,53 @@
+<div class="dropdown is-fullwidth" [class.is-active]="isOpen && (filteredOptions.length > 0 || isLoading || searchText.length >= 3)">
+  <div class="dropdown-trigger" style="width: 100%;">
+    <div class="field has-addons" style="margin-bottom: 0;">
+      @if (selectedPostId != null) {
+        <div class="control is-expanded">
+          <div class="message is-small selected-post-tag">
+            <div class="message-header">
+              <span class="selected-post-text">{{ searchText }}</span>
+              @if (!disabled) {
+                <button type="button" class="delete is-small" (click)="clearSelection()" aria-label="clear selection"></button>
+              }
+            </div>
+          </div>
+        </div>
+      } @else {
+        <div class="control is-expanded">
+          <input
+            class="input is-medium with-floating-label"
+            type="text"
+            placeholder=" "
+            [(ngModel)]="searchText"
+            (input)="onInput()"
+            (focus)="onFocus()"
+            (blur)="onBlur()"
+            (keydown)="onKeyDown($event)"
+            [disabled]="disabled" />
+        </div>
+      }
+    </div>
+  </div>
+  <div class="dropdown-menu" role="listbox" style="width: 100%;">
+    <div class="dropdown-content" style="background-color: #fff; color: #363636; border: 1px solid #dbdbdb; box-shadow: 0 0.5em 1em -0.125em rgba(10,10,10,.1), 0 0 0 1px rgba(10,10,10,.02);">
+      @if (isLoading) {
+        <div class="dropdown-item has-text-grey">
+          <span class="icon is-small"><i class="fas fa-spinner fa-spin"></i></span>
+          <span>Searching...</span>
+        </div>
+      } @else {
+        @for (option of filteredOptions; track option.postId; let i = $index) {
+        <a class="dropdown-item"
+           [class.is-active]="i === highlightedIndex"
+           (click)="selectOption(option)"
+           (mouseenter)="highlightedIndex = i">
+          {{ formatOption(option) }}
+        </a>
+        }
+        @if (filteredOptions.length === 0 && searchText.length >= 3) {
+          <div class="dropdown-item has-text-grey">No matching posts found.</div>
+        }
+      }
+    </div>
+  </div>
+</div>

--- a/abcd.client/src/app/editor/post-autocomplete/post-autocomplete.component.ts
+++ b/abcd.client/src/app/editor/post-autocomplete/post-autocomplete.component.ts
@@ -1,0 +1,151 @@
+import { Component, EventEmitter, HostBinding, Input, Output, OnChanges, OnInit, OnDestroy, SimpleChanges, HostListener, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Subject, Subscription, of } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+import { EditorPostSummary, PostService } from '../../services/post.service';
+
+@Component({
+  selector: 'app-post-autocomplete',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './post-autocomplete.component.html',
+  styleUrls: ['./post-autocomplete.component.css']
+})
+export class PostAutocompleteComponent implements OnChanges, OnInit, OnDestroy {
+  @Input() selectedPostId: number | null = null;
+  @Input() excludePostId: number | null = null;
+  @Input() initialDisplayText: string = '';
+  @Input() disabled = false;
+  @Output() selectedPostIdChange = new EventEmitter<{ postId: number | null, displayText: string }>();
+
+  @HostBinding('class.is-empty') get isEmpty() { return !this.searchText && this.selectedPostId == null; }
+  @HostBinding('class.is-focused') isFocused = false;
+
+  searchText = '';
+  isOpen = false;
+  filteredOptions: EditorPostSummary[] = [];
+  highlightedIndex = -1;
+  isLoading = false;
+
+  private searchSubject = new Subject<string>();
+  private searchSubscription: Subscription | null = null;
+
+  static readonly MIN_SEARCH_LENGTH = 3;
+
+  constructor(private elRef: ElementRef, private postService: PostService) {}
+
+  ngOnInit(): void {
+    this.searchSubscription = this.searchSubject.pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      switchMap(term => {
+        if (term.length < PostAutocompleteComponent.MIN_SEARCH_LENGTH) {
+          this.isLoading = false;
+          return of([]);
+        }
+        this.isLoading = true;
+        return this.postService.searchPosts(term, this.excludePostId ?? undefined);
+      })
+    ).subscribe(results => {
+      this.filteredOptions = results;
+      this.isLoading = false;
+      this.highlightedIndex = -1;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.searchSubscription?.unsubscribe();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['selectedPostId']) {
+      if (this.selectedPostId == null) {
+        this.searchText = '';
+        this.filteredOptions = [];
+      } else if (this.initialDisplayText) {
+        this.searchText = this.initialDisplayText;
+      }
+    }
+    if (changes['initialDisplayText'] && this.initialDisplayText) {
+      this.searchText = this.initialDisplayText;
+    }
+  }
+
+  onFocus(): void {
+    if (this.disabled) return;
+    this.isFocused = true;
+    if (this.searchText.length >= PostAutocompleteComponent.MIN_SEARCH_LENGTH) {
+      this.isOpen = true;
+    }
+  }
+
+  onBlur(): void {
+    this.isFocused = false;
+  }
+
+  onInput(): void {
+    this.isOpen = true;
+    this.selectedPostId = null;
+    this.selectedPostIdChange.emit({ postId: null, displayText: '' });
+    this.searchSubject.next(this.searchText.trim());
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    if (!this.isOpen || this.filteredOptions.length === 0) return;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.highlightedIndex = Math.min(this.highlightedIndex + 1, this.filteredOptions.length - 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0);
+        break;
+      case 'Enter':
+        event.preventDefault();
+        if (this.highlightedIndex >= 0) {
+          this.selectOption(this.filteredOptions[this.highlightedIndex]);
+        }
+        break;
+      case 'Escape':
+        this.close();
+        break;
+    }
+  }
+
+  selectOption(option: EditorPostSummary): void {
+    this.selectedPostId = option.postId;
+    this.searchText = this.formatOption(option);
+    this.selectedPostIdChange.emit({ postId: option.postId, displayText: this.searchText });
+    this.close();
+  }
+
+  clearSelection(): void {
+    this.selectedPostId = null;
+    this.searchText = '';
+    this.filteredOptions = [];
+    this.selectedPostIdChange.emit({ postId: null, displayText: '' });
+  }
+
+  formatOption(option: EditorPostSummary): string {
+    let text = option.title;
+    if (option.pathSegment) {
+      text += ` (${option.pathSegment})`;
+    }
+    return `${text} - ${option.status}`;
+  }
+
+  close(): void {
+    this.isOpen = false;
+    this.highlightedIndex = -1;
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: Event): void {
+    if (!this.elRef.nativeElement.contains(event.target)) {
+      this.close();
+    }
+  }
+}

--- a/abcd.client/src/app/services/post.service.ts
+++ b/abcd.client/src/app/services/post.service.ts
@@ -113,4 +113,12 @@ export class PostService {
   getPublishedPost(pathSegment: string): Observable<PublicPostDetail> {
     return this.http.get<PublicPostDetail>(`/api/public/posts/${pathSegment}`);
   }
+
+  searchPosts(term: string, excludePostId?: number): Observable<EditorPostSummary[]> {
+    let url = `/api/posts/search?term=${encodeURIComponent(term)}`;
+    if (excludePostId != null) {
+      url += `&excludePostId=${excludePostId}`;
+    }
+    return this.http.get<EditorPostSummary[]>(url);
+  }
 }

--- a/abcd.client/src/app/services/post.service.ts
+++ b/abcd.client/src/app/services/post.service.ts
@@ -5,6 +5,14 @@ import { Post } from '../editor/models/post.model';
 import { MoveFragmentRequest } from '../editor/models/move-fragment-request.model'; 
 import { FragmentUpdateRequest } from '../editor/models/fragment-update-request.model';
 
+export interface EditorPostSummary {
+  postId: number;
+  title: string;
+  status: string;
+  pathSegment?: string;
+  dateLastPublished?: string;
+}
+
 export interface PostSummary {
   postId: number;
   title: string;
@@ -34,8 +42,8 @@ export class PostService {
   [x: string]: any;
   constructor(private http: HttpClient) {}
 
-  getPosts(): Observable<any[]> {
-    return this.http.get<any[]>('/api/posts');
+  getPosts(): Observable<EditorPostSummary[]> {
+    return this.http.get<EditorPostSummary[]>('/api/posts');
   }
 
   getPost(postId: number): Observable<Post> {
@@ -78,10 +86,16 @@ export class PostService {
     return this.http.post<ImageUploadResponse>(`/api/file/posts/${postId}/image`, formData);
   }
 
-  savePost(request: Post): Observable<Post> {
+  savePost(request: Post, parentPostId: number | null = request.parent?.postId ?? null): Observable<Post> {
     return this.http.put<Post>(
       `/api/posts/${request.postId}`,
-      { title: request.title, synopsis: request.synopsis, pathSegment: request.pathSegment, version: request.version }
+      {
+        title: request.title,
+        synopsis: request.synopsis,
+        pathSegment: request.pathSegment,
+        parentPostId,
+        version: request.version
+      }
     );
   }
 

--- a/abcd.client/src/styles.scss
+++ b/abcd.client/src/styles.scss
@@ -68,6 +68,33 @@ app-root {
   position: static;
 }
 
+.control.has-floating-label app-post-autocomplete + .label.is-floating-label {
+  transition: 0.2s;
+  pointer-events: none;
+}
+
+.control.has-floating-label app-post-autocomplete.is-empty + .label.is-floating-label {
+  color: #4b5370;
+  top: 1.375rem;
+  left: 0.75rem;
+  z-index: 0;
+  font-size: inherit;
+  background: none;
+  padding: 0;
+}
+
+.control.has-floating-label app-post-autocomplete.is-empty.is-focused + .label.is-floating-label,
+.control.has-floating-label app-post-autocomplete:not(.is-empty) + .label.is-floating-label {
+  color: #868585;
+  top: 0.3rem;
+  left: 0.8rem;
+  z-index: 11;
+  font-size: 0.75rem;
+  background: #fff;
+  padding: 0 0.25rem;
+  pointer-events: auto;
+}
+
 body {
   font-family: 'Open Sans', Helvetica, sans-serif;
   color: #111111;


### PR DESCRIPTION
This pull request introduces support for associating posts with parent posts, allowing posts to be organized into series or trails. It adds backend and frontend functionality for setting, clearing, and displaying a parent post, and implements a search endpoint and autocomplete UI for selecting a parent post. Additional improvements include robust error handling and enhancements to the data mapping logic.

**Parent Post Functionality**

* Added `ParentPostId` to the `UpdatePostCommand` and updated the domain, repository, and service logic to support associating a post with a parent post, including validation and persistence. [[1]](diffhunk://#diff-9f62e5cf9f2db1bd4396f8f520ce7d25905d38a4c0fe9d1fae31cd07a27a2146L10-R10) [[2]](diffhunk://#diff-6486ce4f94133c71b16379d75fd54bb4477a0f695207ac6cfeaa6a085f71fe7cL96-R112) [[3]](diffhunk://#diff-777d537919da576969cb6ff0d87f8adf3c441e8264b81a812591ae96dde6df1cR101-R114) [[4]](diffhunk://#diff-777d537919da576969cb6ff0d87f8adf3c441e8264b81a812591ae96dde6df1cR136) [[5]](diffhunk://#diff-777d537919da576969cb6ff0d87f8adf3c441e8264b81a812591ae96dde6df1cR212) [[6]](diffhunk://#diff-714137c3b7d085e9ee92a5f830292c26c4a555ea22afa76005c4b6536f70edc1L61-R72)
* Updated the API models and mapping to expose parent post information in `PostDetailResponse` and added the `PostParentResponse` record. [[1]](diffhunk://#diff-69037509434ad292f4086db4d1ea3d9d581e29b081904830a623acaae9f003a6R29-R44) [[2]](diffhunk://#diff-54059d3be83da3d640054c4c657789c5ec82d8347e409fca23038344daaadb40R150-R155)
* Added and updated unit tests to verify setting and clearing of parent posts during post updates.

**Post Search and Autocomplete**

* Implemented a backend search endpoint (`/posts/search`) to find posts by title or path segment, with optional exclusion of a specific post (for use in parent selection). [[1]](diffhunk://#diff-5c25d006d5827543d898c98681dfca89c70d6cec6246b59acf67dadfd8639c7eR13) [[2]](diffhunk://#diff-777d537919da576969cb6ff0d87f8adf3c441e8264b81a812591ae96dde6df1cR64-L70) [[3]](diffhunk://#diff-714137c3b7d085e9ee92a5f830292c26c4a555ea22afa76005c4b6536f70edc1R44-R54) [[4]](diffhunk://#diff-1406f834834f6db1faf0700d04f95f098dc384f3e4b9209c658461199369ddcfR16)
* Added a `PostAutocompleteComponent` to the frontend and integrated it into the post editor for selecting a parent post. [[1]](diffhunk://#diff-ab6c0d748162e9b8eec5aa186a5447229b80af24ed6797606918be9c021ac3e7R18) [[2]](diffhunk://#diff-ba7946e27fd5d74871d6d5c0d62eab10322e3563eca1959a2e7d9b8b59bca54bR58-R77) [[3]](diffhunk://#diff-2a9379af8bee54e3d60a393a50dfff64910b73f7e445c6d1a8af8d28bc85b2f5L21-R23) [[4]](diffhunk://#diff-2a9379af8bee54e3d60a393a50dfff64910b73f7e445c6d1a8af8d28bc85b2f5R32-R43) [[5]](diffhunk://#diff-2a9379af8bee54e3d60a393a50dfff64910b73f7e445c6d1a8af8d28bc85b2f5L165-R218)

**Frontend Enhancements**

* Updated the post editor UI and state management to support displaying, selecting, and clearing a parent post, including maintaining original header state and handling parent post changes/cancels. [[1]](diffhunk://#diff-2a9379af8bee54e3d60a393a50dfff64910b73f7e445c6d1a8af8d28bc85b2f5L21-R23) [[2]](diffhunk://#diff-2a9379af8bee54e3d60a393a50dfff64910b73f7e445c6d1a8af8d28bc85b2f5R32-R43) [[3]](diffhunk://#diff-2a9379af8bee54e3d60a393a50dfff64910b73f7e445c6d1a8af8d28bc85b2f5L165-R218) [[4]](diffhunk://#diff-28f333e54acbe4ba55787f20afc7f10386511b9f80e56dcc6c99f8358583be54R7)

**Error Handling**

* Improved exception handling middleware to return HTTP 400 for `ArgumentException` and `ArgumentNullException`, ensuring better feedback for invalid parent relationships.

These changes collectively enable hierarchical organization of posts and provide a user-friendly interface for managing post relationships.